### PR TITLE
Fixes tickets #1 and #2. Unexported functions and u3d_demo crash.

### DIFF
--- a/demo/u3d_demo.tcl
+++ b/demo/u3d_demo.tcl
@@ -18,7 +18,7 @@ HPDF_Page_SetHeight $page 600
 set u3d [HPDF_LoadU3DFromFile $pdf [file join $demodir u3d animal.u3d]]
 set rect1 {left 0 bottom 0 right 600 top 600}
 
-set annot [HPDF_Page_Create3DAnnot $page $rect1 1 0 $u3d NULL]
+set annot [HPDF_Page_Create3DAnnot $page $rect1 $u3d]
 
 # save the document to a file
 set pdffilename [file rootname [file tail [info script]]]


### PR DESCRIPTION
- Some `libhpdf ` builds do not have a version in the names, causing the package to not find them. Instead an explicit version check is now done by calling `HPDF_GetVersion`
- The 2.3.0 `libhpdf ` distribution on Windows is missing exports on some functions causing the package to fail to load. These are now wrapped in a `catch` and ignored. None of the demos make use of these functions. (Bug #1)
- The `HPDF_Page_Create3DAnnot` function API has been fixed to match the 2.3.0 prototype, and not the 2.4 one. `u3d_demo.tcl` fixed accordingly. (Bug #2)