### PR TITLE
Look up libhpdf in platform specific directories

### DIFF
--- a/haru.tcl
+++ b/haru.tcl
@@ -25,7 +25,7 @@ package require Tcl 8.6-
 package require cffi 2.0
 
 namespace eval haru {
-    variable hpdfMinVersion "2.4.5"
+    variable hpdfMinVersion "2.4.3"
     variable version 2.0
     variable packageDirectory [file dirname [file normalize [info script]]]
     variable supportedHpdfVersions [list 2.4.5]

--- a/haru.tcl
+++ b/haru.tcl
@@ -28,7 +28,7 @@ namespace eval haru {
     variable hpdfMinVersion "2.4.3"
     variable version 2.0
     variable packageDirectory [file dirname [file normalize [info script]]]
-    variable supportedHpdfVersions [list 2.4.5]
+    variable supportedHpdfVersions [list 2.4.3 2.4.4 2.4.5]
 
     proc load_hpdf {} {
         # Locates and loads the hpdf shared library

--- a/haru.tcl
+++ b/haru.tcl
@@ -96,7 +96,11 @@ namespace eval haru {
         # On Windows, the latter is probably redundant but...
         lappend searchPaths $packageDirectory
         lappend searchPaths [file dirname [info nameofexecutable]]
-
+# Specific case for macOS where the shared library is installed
+# under '/usr/local/lib'.
+if {$::tcl_platform(platform) eq "unix"} {
+    set searchPaths [linsert $searchPaths 0 "/usr/local/lib"]
+}
         # Now do the actual search over search path for each possible name
         foreach searchPath $searchPaths {
             foreach fileName $fileNames {

--- a/haru.tcl
+++ b/haru.tcl
@@ -25,40 +25,102 @@ package require Tcl 8.6-
 package require cffi 2.0
 
 namespace eval haru {
-    variable hpdfversion "2.4.5"
+    variable hpdfMinVersion "2.4.5"
     variable version 2.0
+    variable packageDirectory [file dirname [file normalize [info script]]]
+    variable supportedHpdfVersions [list 2.4.5]
+
+    proc load_hpdf {} {
+        # Locates and loads the hpdf shared library
+        #
+        # Tries in order
+        #   - the system default search path
+        #   - platform specific subdirectories under the package directory
+        #   - the toplevel package directory
+        #   - the directory where the main program is installed
+        # If all fail, simply tries the name as is in which case the
+        # system will look up in the standard shared library search path.
+        #
+        # On success, creates the HPDF cffi::Wrapper object in the global
+        # namespace.
+
+        variable packageDirectory
+        variable supportedHpdfVersions
+
+        # First make up list of possible shared library names depending
+        # on platform and supported shared library versions.
+        set ext [info sharedlibextension]
+        if {$::tcl_platform(platform) eq "windows"} {
+            # Names depend on compiler (mingw/vc). VC -> hpdf, mingw -> libhpdf
+            # Examples: hpdf.dll, libhpdf.dll, hpdfVERSION.dll, hpdf-VERSION.dll
+            foreach baseName {hpdf libhpdf} {
+                foreach hpdfVersion $supportedHpdfVersions {
+                    lappend fileNames $baseName$hpdfVersion$ext \
+                        $baseName-$hpdfVersion$ext
+                }
+                lappend fileNames $baseName$ext
+            }
+        } else {
+            # Unix: libhpdf.so, libhpdfVERSION.so, libhpdf-VERSION.so, libhpdf.so.VERSION
+            foreach hpdfVersion $supportedHpdfVersions {
+                lappend fileNames libhpdf$hpdfVersion$ext \
+                    libhpdf.$hpdfVersion$ext \
+                    libhpdf-$hpdfVersion$ext
+            }
+            lappend fileNames libhpdf$ext
+        }
+
+        set attempts {}
+
+        # First try the system default search paths by no explicitly
+        # specifying the full path
+        foreach fileName $fileNames {
+            if {![catch {
+                cffi::Wrapper create ::HPDF $fileName
+            } err]} {
+                return
+            }
+            append attempts $fileName : $err \n
+        }
+
+        # Not on default search path. Look under platform specific directories
+        # under the package directory.
+        package require platform
+        set searchPaths [lmap platform [platform::patterns [platform::identify]] {
+            if {$platform eq "tcl"} {
+                continue
+            }
+            file join $packageDirectory $platform
+        }]
+        # Also look in package directory and location of main executable.
+        # On Windows, the latter is probably redundant but...
+        lappend searchPaths $packageDirectory
+        lappend searchPaths [file dirname [info nameofexecutable]]
+
+        # Now do the actual search over search path for each possible name
+        foreach searchPath $searchPaths {
+            foreach fileName $fileNames {
+                set path [file join $searchPath $fileName]
+                if {![catch {
+                    cffi::Wrapper create ::HPDF $path
+                } err]} {
+                    return
+                }
+                append attempts $path : $err \n
+            }
+        }
+        return -code error "Failed to load libhpdf:\n$attempts"
+    }
 }
 
-# Try checking several places..
-set lib_names [subst {
-    libhpdf 
-    hpdf
-    /usr/local/lib/libhpdf
-    libhpdf.$::haru::hpdfversion
-    libhpdf-$::haru::hpdfversion
-}]
-
-set lib_found 0
-set lname {}
-
-foreach name $lib_names {
-    if {![catch {
-        cffi::Wrapper create HPDF ${name}[info sharedlibextension]
-    } err]
-    } {
-        set lib_found 1; break
-    }; lappend lname $err
-}
-
-# Generate error message if lib not found.
-if {!$lib_found} {return -code error [join $lname \n]}
+haru::load_hpdf
 
 # Gets hpdf version.
 HPDF stdcall HPDF_GetVersion string {}
 
-if {[package vcompare [HPDF_GetVersion] $::haru::hpdfversion] < 0} {
+if {[package vcompare [HPDF_GetVersion] $::haru::hpdfMinVersion] < 0} {
     error "libhpdf version '[HPDF_GetVersion]' is\
-           unsupported. Need '$::haru::hpdfversion' or later."
+           unsupported. Need '$::haru::hpdfMinVersion' or later."
 }
 
 package provide haru $::haru::version


### PR DESCRIPTION
This patch extends the search path where haru looks for the hpdf shared library. Even if this patch is not accepted, at least the code should be modified to also check if the DLL is present in the package directory on Windows.